### PR TITLE
Strict option

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function(str, options) {
     } else {
       if (substr === '"') {
         closeIdx = getClose(str, '"', idx + 1);
-        if (closeIdx === -1) {
+        if (closeIdx === -1 && opts.strict !== false) {
           throw new Error('unclosed double quote: ' + str);
         }
 
@@ -53,7 +53,7 @@ module.exports = function(str, options) {
 
       if (substr === '\'') {
         closeIdx = getClose(str, '\'', idx + 1);
-        if (closeIdx === -1) {
+        if (closeIdx === -1 && opts.strict !== false) {
           throw new Error('unclosed single quote: ' + str);
         }
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = function(str, options) {
       if (substr === '\'') {
         closeIdx = getClose(str, '\'', idx + 1);
         if (closeIdx === -1) {
-          throw new Error('unclosed double quote: ' + str);
+          throw new Error('unclosed single quote: ' + str);
         }
 
         if (opts.keepSingleQuotes === true) {

--- a/index.js
+++ b/index.js
@@ -38,8 +38,11 @@ module.exports = function(str, options) {
     } else {
       if (substr === '"') {
         closeIdx = getClose(str, '"', idx + 1);
-        if (closeIdx === -1 && opts.strict !== false) {
-          throw new Error('unclosed double quote: ' + str);
+        if (closeIdx === -1) {
+          if (opts.strict !== false) {
+            throw new Error('unclosed double quote: ' + str);
+          }
+          closeIdx = idx;
         }
 
         if (opts.keepDoubleQuotes === true) {
@@ -53,8 +56,11 @@ module.exports = function(str, options) {
 
       if (substr === '\'') {
         closeIdx = getClose(str, '\'', idx + 1);
-        if (closeIdx === -1 && opts.strict !== false) {
-          throw new Error('unclosed single quote: ' + str);
+        if (closeIdx === -1) {
+          if (opts.strict !== false) {
+              throw new Error('unclosed single quote: ' + str);
+          }
+          closeIdx = idx;
         }
 
         if (opts.keepSingleQuotes === true) {

--- a/test.js
+++ b/test.js
@@ -47,4 +47,34 @@ describe('split', function () {
   it('should not split on escaped dots:', function () {
     assert.deepEqual(split('a.b.c\\.d'), ['a', 'b', 'c.d']);
   });
+
+  it('should throw an error for unclosed double quotes', function(cb) {
+    try {
+      split('a."b.c');
+      cb(new Error('expected an error'));
+    } catch (err) {
+      assert(err);
+      assert.equal(err.message, 'unclosed double quote: a."b.c');
+      cb();
+    }
+  });
+
+  it('should throw an error for unclosed single quotes', function(cb) {
+    try {
+      split('a.\'b.c');
+      cb(new Error('expected an error'));
+    } catch (err) {
+      assert(err);
+      assert.equal(err.message, 'unclosed single quote: a.\'b.c');
+      cb();
+    }
+  });
+
+  it('should not throw an error for unclosed double quotes when strict is false', function() {
+    assert.deepEqual(split('a."b.c', {strict: false}), ['a', 'b', 'c']);
+  });
+
+  it('should not throw an error for unclosed single quotes when strict is false', function() {
+    assert.deepEqual(split('a.\'b.c', {strict: false}), ['a', 'b', 'c']);
+  });
 });


### PR DESCRIPTION
This PR adds a `strict` option to turn off throwing an error if a string has unclosed quotes.
I can see how this is useful for single quotes like `'doowb\'s'`. I'm not sure when it makes sense for double quotes, but it handles that too.

I also changed the error message for single quotes to `unclosed single quote` so it differentiates between the two.

Let me know if this looks okay or if you think there might be a better way of doing this.