### PR TITLE
allow options.quotes to be an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,21 @@ module.exports = function(str, options, fn) {
   }
 
   var opts = extend({sep: '.'}, options);
-  var quotes = opts.quotes || ['"', "'", '`'];
-  var brackets;
+  var quotes = opts.quotes || {
+    '"': '"',
+    "'": "'",
+    '`': '`',
+    '“': '”'
+  };
 
+  if (Array.isArray(quotes)) {
+    quotes = quotes.reduce(function(acc, ele) {
+      acc[ele] = ele;
+      return acc;
+    }, {});
+  }
+
+  var brackets;
   if (opts.brackets === true) {
     brackets = {
       '<': '>',
@@ -83,8 +95,8 @@ module.exports = function(str, options, fn) {
             continue;
           }
 
-          if (quotes.indexOf(s) !== -1) {
-            i = getClosingQuote(str, s, i + 1);
+          if (quotes[s]) {
+            i = getClosingQuote(str, quotes[s], i + 1);
             continue;
           }
 
@@ -115,8 +127,8 @@ module.exports = function(str, options, fn) {
       tok.idx = idx = closeIdx;
     }
 
-    if (quotes.indexOf(ch) !== -1) {
-      closeIdx = getClosingQuote(str, ch, idx + 1);
+    if (quotes[ch]) {
+      closeIdx = getClosingQuote(str, quotes[ch], idx + 1);
       if (closeIdx === -1) {
         arr[arr.length - 1] += ch;
         continue;
@@ -158,7 +170,7 @@ function getClosingQuote(str, ch, i, brackets) {
 }
 
 function keepQuotes(ch, opts) {
-  if (opts.keepDoubleQuotes === true && ch === '"') return true;
+  if (opts.keepDoubleQuotes === true && (ch === '"' || ch === '“' || ch === '”')) return true;
   if (opts.keepSingleQuotes === true && ch === "'") return true;
   return opts.keepQuotes;
 }

--- a/test.js
+++ b/test.js
@@ -40,6 +40,13 @@ describe('split-string', function() {
       assert.deepEqual(split('a.`b.c`.d.`.e.f.g.`.h'), ['a', 'b.c', 'd', '.e.f.g.', 'h']);
     });
 
+    it('should respect strings in “” double quotes', function() {
+      assert.deepEqual(split('“b.c”'), ['b.c']);
+      assert.deepEqual(split('a.“b.c”'), ['a', 'b.c']);
+      assert.deepEqual(split('a.“b.c”.d'), ['a', 'b.c', 'd']);
+      assert.deepEqual(split('a.“b.c”.d.“.e.f.g.”.h'), ['a', 'b.c', 'd', '.e.f.g.', 'h']);
+    });
+
     it('should not split on escaped dots:', function() {
       assert.deepEqual(split('a.b.c\\.d'), ['a', 'b', 'c.d']);
     });
@@ -62,6 +69,10 @@ describe('split-string', function() {
   describe('options', function() {
     it('should keep double quotes', function() {
       assert.deepEqual(split('a."b.c".d', {keepDoubleQuotes: true}), ['a', '"b.c"', 'd']);
+    });
+
+    it('should keep “” double quotes', function() {
+      assert.deepEqual(split('a.“b.c”.d', {keepDoubleQuotes: true}), ['a', '“b.c”', 'd']);
     });
 
     it('should not split inside brackets', function() {
@@ -108,6 +119,14 @@ describe('split-string', function() {
 
     it('should split on a custom separator', function() {
       assert.deepEqual(split('a,b,c', {sep: ','}), ['a', 'b', 'c']);
+    });
+
+    it('should allow custom quotes array', function() {
+      assert.deepEqual(split('a.^b.c^', {quotes: ['^']}), ['a', 'b.c']);
+    });
+
+    it('should allow custom quotes object', function() {
+      assert.deepEqual(split('a.^b.c$', {quotes: {'^': '$'}}), ['a', 'b.c']);
     });
   });
 


### PR DESCRIPTION
From the discussion in #3 

- allow passing an object of `{open:close}` quote combos
- convert array to object
- added tests for different open and close quotes.
- closes #3
