### PR TITLE
separator -> sep in docs.

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -129,7 +129,7 @@ console.log(split('a.b\\.c')); //=> ['a', 'b.c']
 console.log(split('a.b.\\c', { keep: () => true })); //=> ['a', 'b\.c']
 ```
 
-### options.separator
+### options.sep
 
 **Type**: `string`
 
@@ -140,7 +140,7 @@ The character to split on.
 **Example**
 
 ```js
-console.log(split('a.b,c', { separator: ',' })); //=> ['a.b', 'c']
+console.log(split('a.b,c', { sep: ',' })); //=> ['a.b', 'c']
 ```
 
 ## Split function
@@ -158,7 +158,7 @@ console.log(split('a.b.c.a.d.e', state => state.prev() === 'a'));
 The `state` object exposes the following properties:
 
 - `input` - (String) The un-modified, user-defined input string
-- `separator` - (String) the specified separator to split on.
+- `sep` - (String) the specified separator to split on.
 - `index` - (Number) The current cursor position
 - `value` - (String) The character at the current index
 - `bos` - (Function) Returns true if position is at the beginning-of-string


### PR DESCRIPTION
Reflect change from `separator` to `sep` in the options.