### PR TITLE
Fix typescript export declaration

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,32 +1,41 @@
 // TypeScript Version: 3.0
 
-export interface ASTNode {
-  type: 'root' | 'bracket';
-  nodes: ASTNode[];
-  stash: string[];
+declare module 'split-string' {
+  function split(input: string, options?: split.Options | split.SplitFunc): string[];
+  function split(input: string, options: split.Options, fn: split.SplitFunc): string[];
+
+  namespace split {
+    interface ASTNode {
+      type: 'root' | 'bracket';
+      nodes: ASTNode[];
+      stash: string[];
+    }
+
+    interface State {
+      input: string;
+      separator: string;
+      stack: ASTNode[];
+
+      bos(): boolean;
+
+      eos(): boolean;
+
+      prev(): string;
+
+      next(): string;
+    }
+
+    interface Options {
+      brackets?: { [key: string]: string } | boolean;
+      quotes?: string[] | boolean;
+      separator?: string;
+      strict?: boolean;
+
+      keep?(value: string, state: State): boolean;
+    }
+
+    type SplitFunc = (state: State) => boolean;
+  }
+
+  export = split;
 }
-
-export interface State {
-  input: string;
-  separator: string;
-  stack: ASTNode[];
-  bos(): boolean;
-  eos(): boolean;
-  prev(): string;
-  next(): string;
-}
-
-export interface Options {
-  brackets?: { [key: string]: string } | boolean;
-  quotes?: string[] | boolean;
-  separator?: string;
-  strict?: boolean;
-  keep?(value: string, state: State): boolean;
-}
-
-type SplitFunc = (state: State) => boolean;
-
-declare function split(input: string, options?: Options | SplitFunc): string[];
-declare function split(input: string, options: Options, fn: SplitFunc): string[];
-
-export default split;

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,14 +1,13 @@
 /**
  * Testing the TypeScript definitions for split-string.
  */
-import split, { State } from '.';
+import * as split from 'split-string';
 
-function keep(value: string, state: State) {
+function keep(value: string, state: split.State) {
   return value !== '\\' && (value !== '"' || state.prev() === '\\');
 }
 
-function splitFunc(state: State) {
-  console.log(state);
+function splitFunc(state: split.State) {
   return state.prev() === 'a';
 }
 

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -6,6 +6,9 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
-    "noEmit": true
+    "moduleResolution": "node",
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": { "split-string": ["."] }
   }
 }

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,6 +1,6 @@
 {
   "extends": "dtslint/dtslint.json",
   "rules": {
-    "no-relative-import-in-test": false
+    "no-single-declare-module": false
   }
 }


### PR DESCRIPTION
Hi !

The goal of this pull request is to fix the typescript module export declaration in `types/index.d.ts`.
The typescript export that is currently declared does not exactly correspond to the javascript export that is actually made. It still works on some typescript configurations with custom options, but it fails on my system with a very basic configuration. 

This is easily fixed by replacing `export default split` with `export = split`. This then allow to correctly import this module from typescript like this: `import * as split from 'split-string'`. 

See this link for more informations: https://github.com/Microsoft/TypeScript/issues/5565

Thank you !